### PR TITLE
add functionality to take on unordered lists as well as adjusted, flow control of program.

### DIFF
--- a/app/chisel.js
+++ b/app/chisel.js
@@ -7,23 +7,36 @@ const MasterListFormatter = require('./masterListFormatter')
 
 class Chisel {
   constructor(markdown) {
+    this.markdown = markdown;
     this.body = this.extractBody(markdown);
     this.head = this.extractHead(markdown);
-    this.tf = new TextFormatter(this.body);
+    this.mlf = new MasterListFormatter(this.body);
+    this.tf = new TextFormatter();
+    /*
     this.lf = new LineFormatter(this.convergeMessage());
-    this.mlf = new MasterListFormatter(this.tf.formatText());
+    */
   }
 
   convertMarkdown() {
-    return this.lf.applyTags();
+    if (this.mlf.masterListValidation()) {
+      this.tf.markdown = this.mlf.constructList();
+    }
+    else {
+      this.tf.markdown = this.markdown;
+    }
+    return this.tf.formatText();
   };
+
+  listFormatting() {
+    return this.mlf.constructList();
+  }
 
   extractBody(markdown) {
     let message = markdown.split(' ')
     if (markdown[0] === '#') {
       message.splice(0, 1);
       let body = message.join(' ');
-      return body.concat(' ');
+      return body;
     }
     else {
       return message.join(' ').concat(' ');

--- a/app/emFormatter.js
+++ b/app/emFormatter.js
@@ -4,8 +4,8 @@ class EmFormatter {
   }
 
   formatEm() {
-    let html = this.markdown.replace(' *', ' <em>').replace('* ', '</em> ');
-    return html.trim();
+    let html = this.markdown.replace('*', '<em>').replace('*', '</em>');
+    return html;
   }
 }
 module.exports = EmFormatter;

--- a/app/masterListFormatter.js
+++ b/app/masterListFormatter.js
@@ -1,13 +1,22 @@
 const UnorderedListFormatter = require('./unorderedListFormatter');
 
 class MasterListFormatter {
-  constructor(semiParsedMarkdown) {
-    this.message = semiParsedMarkdown;
-    this.ulf = new UnorderedListFormatter(this.message);
+  constructor(markdown) {
+    this.markdown = markdown;
+    this.ulf = new UnorderedListFormatter(this.markdown);
+  }
+
+  masterListValidation() {
+    if (this.ulf.unorderedListValidation()) {
+      return true;
+    }
+    else {
+      return false;
+    }
   }
 
   constructList() {
-    return this.ulf.formatList();
+    return this.ulf.constructUnorderedList();
   }
 }
-module.exports = MasterListFormatter;
+module.exports = MasterListFormatter

--- a/app/strongFormatter.js
+++ b/app/strongFormatter.js
@@ -4,7 +4,7 @@ class StrongFormatter {
   };
 
   formatStrong() {
-    let html = this.markdown.replace(' **', ' <strong>').replace('** ', '</strong> ');
+    let html = this.markdown.replace('**', '<strong>').replace('**', '</strong>');
     return html;
   }
 }

--- a/app/textFormatter.js
+++ b/app/textFormatter.js
@@ -4,11 +4,12 @@ const EmFormatter = require('./emFormatter');
 class TextFormatter {
   constructor(parsedMarkdown) {
     this.markdown = parsedMarkdown;
-    this.sf = new StrongFormatter(this.markdown);
+    this.sf = new StrongFormatter;
     this.ef = new EmFormatter;
   }
 
   formatText() {
+    this.sf.markdown = this.markdown
     this.ef.markdown = this.sf.formatStrong();
     return this.ef.formatEm();
   }

--- a/app/unorderedListFormatter.js
+++ b/app/unorderedListFormatter.js
@@ -1,18 +1,32 @@
 class UnorderedListFormatter {
-  constructor(semiParsedMarkdown) {
-    this.message = semiParsedMarkdown;
+  constructor(markdown) {
+    this.markdown = markdown;
+    this.listItem = this.markdown.indexOf('\n* ');
   }
 
-  formatList() {
-    let contents = this.listItems()
+  unorderedListValidation() {
+    if (this.listItem === -1) {
+      return false;
+    }
+    else {
+      return true
+    }
   }
 
-  listItems() {
-    return this.message.split('*').join('</li>\n<li>');
+  constructUnorderedList() {
+    if (this.unorderedListValidation()) {
+      let extractedList = this.markdown.slice(this.listItem);
+      return this.formatUnorderedList(extractedList);
+    }
   }
 
-  applyListTags() {
-    return this.listItems().replace('</li>', '<ul>\n').concat('</li>\n</ul>')
+  formatUnorderedList(message) {
+    let listItems = message.split('\n* ').slice(1);
+    let list = ''
+    for (var l of listItems) {
+      list += `<li>${l.trim()}</li>\n`
+    }
+    return `<ul>\n${list}</ul>\n`
   }
 }
 module.exports = UnorderedListFormatter;

--- a/test/it-does-ordered-lists-test.js
+++ b/test/it-does-ordered-lists-test.js
@@ -1,0 +1,29 @@
+'use strict'
+const expect = require('chai').expect;
+const MasterListFormatter = require('../app/masterListFormatter');
+const Chisel = require('../app/chisel');
+
+describe('it does unordered lists', function() {
+  describe('it can handle converting numbered items to ordered lists', function() {
+    it('knows how to convert ordered lists', function() {
+      let mlf = new MasterListFormatter('\n1. Sushi\n2. Barbeque\n3. Mexican');
+      let expectedResult = '<ol>\n<li>Sushi</li>\n<li>Barbeque</li>\n<li>Mexican</li>\n</ol>\n';
+
+      expect(mlf.constructList()).to.equal(expectedResult);
+    });
+
+    it("can convert ordered lists with ** items", function(){
+      let chisel = new Chisel('\n1. Sushi\n2. **Barbeque**\n3. Mexican');
+      let expectedResult = '<ol>\n<li>Sushi</li>\n<li><strong>Barbeque</strong></li>\n<li>Mexican</li>\n</ol>\n';
+
+      expect(chisel.convertMarkdown()).to.equal(expectedResult);
+    });
+
+    it("can convert ordered lists with * items", function(){
+      let chisel = new Chisel('\n1. Sushi\n2. *Barbeque*\n3. Mexican');
+      let expectedResult = '<ol>\n<li>Sushi</li>\n<li><em>Barbeque</em></li>\n<li>Mexican</li>\n</ol>\n';
+      
+      expect(chisel.convertMarkdown()).to.equal(expectedResult);
+    });
+  });
+

--- a/test/it-does-text-formatting-test.js
+++ b/test/it-does-text-formatting-test.js
@@ -20,6 +20,13 @@ describe('it does text formatting', function(){
   });
 
   describe("it returns <em> tags in place of text wrapped in '*'", function(){
+    it('can convert text in lists', function(){
+      let chisel = new Chisel('\n* Sushi\n* *Barbeque*\n* Mexican');
+      let expectedResult = '<ul>\n<li>Sushi</li>\n<li><em>Barbeque</em></li>\n<li>Mexican</li>\n</ul>\n';
+
+      expect(chisel.convertMarkdown()).to.equal(expectedResult);
+    });
+
     it('can convert text in header', function(){
       let chisel = new Chisel('## I love *fish* tacos.');
       let expectedResult = '<h2>I love <em>fish</em> tacos.</h2>';

--- a/test/it-does-unordered-lists-test.js
+++ b/test/it-does-unordered-lists-test.js
@@ -1,14 +1,38 @@
 'use strict'
 const expect = require('chai').expect;
+const MasterListFormatter = require('../app/masterListFormatter');
 const Chisel = require('../app/chisel');
 
 describe('it does unordered lists', function() {
   describe('it can handle converting bullets to unordered lists', function() {
-    xit('knows how to convert unordered lists', function() {
-      let chisel = new Chisel('My favorite cuisines are:\n* Sushi\n* Barbeque\n * Mexican');
-      let expectedResult = '<p>My favorite cuisines are:</p>\n<ul>\n\t<li>Sushi</li>\n\t<li>Barbeque</li>\n\t<li>Mexican</li>\n</ul>';
+    it('knows how to convert unordered lists', function() {
+      let mlf = new MasterListFormatter('\n* Sushi\n* Barbeque\n* Mexican');
+      let expectedResult = '<ul>\n<li>Sushi</li>\n<li>Barbeque</li>\n<li>Mexican</li>\n</ul>\n';
+
+      expect(mlf.constructList()).to.equal(expectedResult);
+    });
+
+    it("can convert unordered lists with ** items", function(){
+      let chisel = new Chisel('\n* Sushi\n* **Barbeque**\n* Mexican');
+      let expectedResult = '<ul>\n<li>Sushi</li>\n<li><strong>Barbeque</strong></li>\n<li>Mexican</li>\n</ul>\n';
 
       expect(chisel.convertMarkdown()).to.equal(expectedResult);
     });
+
+    it("can convert unordered lists with * items", function(){
+      let chisel = new Chisel('\n* Sushi\n* *Barbeque*\n* Mexican');
+      let expectedResult = '<ul>\n<li>Sushi</li>\n<li><em>Barbeque</em></li>\n<li>Mexican</li>\n</ul>\n';
+      
+      expect(chisel.convertMarkdown()).to.equal(expectedResult);
+    });
+  });
+
+  describe('it can handle bullets preceded by headers', function() {
+    xit('can convert lists with a paragraph before', function() {
+      let chisel = new Chisel('My favorite cuisines are:\n\n* Sushi\n* Barbeque\n* Mexican');
+      let expectedResult = '<p>My favorite cuisines are:</p>\n\n<ul>\n<li>Sushi</li>\n<li>Barbque</li>\n<li>Mexican</li>\n</ul>\n';
+
+      expect(chisel.convertMarkdown()).to.equal(expectedResult);
+    })
   });
 });


### PR DESCRIPTION
List moves to the top of the list in conversions after validation due to it's similar syntax to <em> tags. Consider further compartmentalizing classes and use chisel as primary delegator
